### PR TITLE
自環境でビルドが通らない不具合を修正

### DIFF
--- a/BveEx.Launcher/Hosting/BveExRepositoryHost.cs
+++ b/BveEx.Launcher/Hosting/BveExRepositoryHost.cs
@@ -13,7 +13,7 @@ namespace BveEx.Launcher.Hosting
     internal sealed class BveExRepositoryHost
     {
         private const string RepositoryOwner = "automatic9045";
-        private const string RepositoryName = "BveEx";
+        private const string RepositoryName = "BveEX";
 
         public BveExRepositoryHost()
         {

--- a/BveEx.Launcher/Hosting/BveExRepositoryHost.cs
+++ b/BveEx.Launcher/Hosting/BveExRepositoryHost.cs
@@ -13,7 +13,7 @@ namespace BveEx.Launcher.Hosting
     internal sealed class BveExRepositoryHost
     {
         private const string RepositoryOwner = "automatic9045";
-        private const string RepositoryName = "AtsEX";
+        private const string RepositoryName = "BveEx";
 
         public BveExRepositoryHost()
         {

--- a/BveEx.Launcher/LegacyCoreHost.cs
+++ b/BveEx.Launcher/LegacyCoreHost.cs
@@ -6,8 +6,8 @@ using System.Text;
 using System.Threading.Tasks;
 using System.Windows.Forms;
 
-using AtsEx.Native;
-using AtsEx.Native.InputDevices;
+using BveEx.Native;
+using BveEx.Native.InputDevices;
 
 using BveEx.Launcher.Hosting;
 


### PR DESCRIPTION
おま環かもしれないですが、手元の環境ではこの修正でビルドが通るようになったので報告がてらプルリクを立てておきます。
namespaceの変え忘れで死んでいたみたいで、reponameは多分変えなくてもビルド通る気がします。
コードをしっかり読んだわけではなくエラーを見て適当に置換しただけなので、意図と違う修正をしていたらすみません。