### PR TITLE
VersionFormのタブパネルでHiDPI対応

### DIFF
--- a/BveEx/VersionForm/VersionForm.gui.cs
+++ b/BveEx/VersionForm/VersionForm.gui.cs
@@ -29,6 +29,7 @@ namespace BveEx
         private Label PluginListHeader;
         private Dictionary<int, PluginListTabPage> PluginListPages;
         private TabControl PluginList;
+        private Panel PluginListPanel;
 
         private Button OK;
 
@@ -151,14 +152,20 @@ namespace BveEx
 
             PluginList = new TabControl()
             {
+                Dock = DockStyle.Fill,
+            };
+            PluginList.TabPages.AddRange(PluginListPages.Values.ToArray());
+            Controls.Add(PluginList);
+
+            PluginListPanel = new Panel()
+            {
                 Left = 16,
                 Top = 216,
                 Width = 768,
                 Height = 224,
             };
-            PluginList.TabPages.AddRange(PluginListPages.Values.ToArray());
-            Controls.Add(PluginList);
-
+            PluginListPanel.Controls.Add(PluginList);
+            Controls.Add(PluginListPanel);
 
             OK = new Button()
             {

--- a/BveEx/VersionForm/VersionForm.gui.cs
+++ b/BveEx/VersionForm/VersionForm.gui.cs
@@ -155,7 +155,6 @@ namespace BveEx
                 Dock = DockStyle.Fill,
             };
             PluginList.TabPages.AddRange(PluginListPages.Values.ToArray());
-            Controls.Add(PluginList);
 
             PluginListPanel = new Panel()
             {


### PR DESCRIPTION
HiDPI環境にてバージョン情報フォームでタブパネルのスケーリングに失敗する問題を修正しました。

この問題はTabPanelがHiDPIのスケーリングに対応していないことに起因しているため、HiDPIに対応しているコンポーネントの上に乗せることで対処できます。

PanelはHiDPIに対応しており、スケーリングに応じて自動的にリサイズされるためその性質を利用してPanel目いっぱいにタブパネルを乗せることで疑似的にHiDPIに対応しています。

Bve5、BVE6にて確認しました。